### PR TITLE
chore: add CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches:
+            - 'main'
+
+jobs:
+  tests:
+    name: PHPUnit (🐘 ${{ matrix.php-versions }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['8.4', '8.5']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 🐘 Setup PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        with:
+          php-version: ${{ matrix.php-versions }}
+
+      - name: 🎵 Install Composer dependencies
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1
+        env:
+            APP_ENV: test
+
+      - name: 💾 Create cache and test database
+        run: |
+          bin/console cache:warmup
+          bin/console doctrine:schema:update --force
+        env:
+          APP_ENV: test
+
+      - name: 🧪 Run tests
+        run: vendor/bin/phpunit --testdox --testdox-summary
+        env:
+            APP_ENV: test

--- a/tests/BookTest.php
+++ b/tests/BookTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Dto\BookCollection;
 use App\Entity\Book as BookEntity;
 use App\ApiResource\Book;
 use Doctrine\ORM\EntityManagerInterface;
@@ -50,7 +51,7 @@ final class BookTest extends ApiTestCase
         static::createClient()->request('GET', '/api/books');
 
         static::assertResponseIsSuccessful();
-        static::assertMatchesResourceCollectionJsonSchema(Book::class);
+        static::assertMatchesResourceCollectionJsonSchema(BookCollection::class);
         static::assertJsonContains([
             'totalItems' => 2,
             'member' => [
@@ -62,7 +63,7 @@ final class BookTest extends ApiTestCase
         static::createClient()->request('GET', '/api/books?name=2');
 
         static::assertResponseIsSuccessful();
-        static::assertMatchesResourceCollectionJsonSchema(Book::class);
+        static::assertMatchesResourceCollectionJsonSchema(BookCollection::class);
         static::assertJsonContains([
             'totalItems' => 1,
             'member' => [
@@ -73,7 +74,7 @@ final class BookTest extends ApiTestCase
         static::createClient()->request('GET', '/api/books?isbn=9781794890268');
 
         static::assertResponseIsSuccessful();
-        static::assertMatchesResourceCollectionJsonSchema(Book::class);
+        static::assertMatchesResourceCollectionJsonSchema(BookCollection::class);
         static::assertJsonContains([
             'totalItems' => 1,
             'member' => [


### PR DESCRIPTION
`static::assertMatchesResourceCollectionJsonSchema(Book::class);` is currently crashing:

> ApiPlatform\Metadata\Exception\OperationNotFoundException: Operation "" not found for resource "Book".

Update: this has been fixed by changing the class passed to `assertMatchesResourceCollectionJsonSchema`.

---

CI is already running on:

- https://github.com/alexislefebvre/sfcon-apip/pull/2